### PR TITLE
Revert "debootstrap: Improve devpts mounting"

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -87,7 +87,7 @@ recipe_build_debootstrap() {
     # Mount special filesystem in the debootstrap build root
     mount -n -tproc none $BUILD_ROOT/$myroot/proc
     mount -n -tsysfs -o ro none $BUILD_ROOT/$myroot/sys
-    mount -n -tdevpts -omode=0620,ptmxmode=0666,gid=5,newinstance, none $BUILD_ROOT/$myroot/dev/pts
+    mount -n -tdevpts -omode=0620,gid=5 none $BUILD_ROOT/$myroot/dev/pts
     mkdir -p $BUILD_ROOT/$myroot/dev/shm
     mount -n -ttmpfs none $BUILD_ROOT/$myroot/dev/shm
 


### PR DESCRIPTION
This reverts commit fc08c45072851779ce67fa2f92e509dc39e5ed27. More
recent debootstrap has been fixed to only create the /dev/ptmx symlink
if it can't make an actual node. Since our workers run in chroots rather
than containers, the previous behavior without newinstance is the right
thing to do. Probably build-recipe-debootstrap needs a similar check
like debootstrap to see if ptxmode=666 is needed.

https://phabricator.endlessm.com/T14726