### PR TITLE
Debootstrap cleanup

### DIFF
--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -99,12 +99,8 @@ recipe_build_debootstrap() {
     # do the build
     dsc_build "$BUILD_ROOT/$myroot"
 
-    umount -n $BUILD_ROOT/$myroot/proc/sys/fs/binfmt_misc 2>/dev/null || true
-    umount -n $BUILD_ROOT/$myroot/proc
-    umount -n $BUILD_ROOT/$myroot/sys
-    umount -n $BUILD_ROOT/$myroot/dev/pts
-    umount -n $BUILD_ROOT/$myroot/dev/shm
-    umount -n $BUILD_ROOT/$myroot/run/shm 2>/dev/null || true
+    # cleanup the debootstrap root
+    recipe_cleanup_debootstrap
 
     # move topdir back
     mv "$BUILD_ROOT/$myroot/$TOPDIR" "$BUILD_ROOT/${TOPDIR%/*}"
@@ -118,6 +114,15 @@ recipe_resultdirs_debootstrap() {
 }
 
 recipe_cleanup_debootstrap() {
-    :
+    local myroot=debootstraproot
+
+    if test -n "$BUILD_ROOT" -a -d "$BUILD_ROOT/$myroot" ; then
+        umount -n $BUILD_ROOT/$myroot/proc/sys/fs/binfmt_misc 2>/dev/null || true
+        umount -n $BUILD_ROOT/$myroot/proc 2>/dev/null || true
+        umount -n $BUILD_ROOT/$myroot/sys 2>/dev/null || true
+        umount -n $BUILD_ROOT/$myroot/dev/pts 2>/dev/null || true
+        umount -n $BUILD_ROOT/$myroot/dev/shm 2>/dev/null || true
+        umount -n $BUILD_ROOT/$myroot/run/shm 2>/dev/null || true
+    fi
 }
 

--- a/build-recipe-debootstrap
+++ b/build-recipe-debootstrap
@@ -48,7 +48,11 @@ recipe_build_debootstrap() {
 	FULL_PKG_LIST="$FULL_PKG_LIST,${PKG%.deb}"
     done
     FULL_PKG_LIST="${FULL_PKG_LIST#,}"
+
+    # cleanup any existing debootstrap root
+    recipe_cleanup_debootstrap
     rm -rf "$BUILD_ROOT/$myroot"
+
     mkdir -p "$BUILD_ROOT/$myroot/etc/dpkg/dpkg.cfg.d"
     echo force-unsafe-io > "$BUILD_ROOT/$myroot/etc/dpkg/dpkg.cfg.d/force-unsafe-io"
 


### PR DESCRIPTION
Unmount from the inner debootstrap root more robustly. This should make killing a running build not leave the worker unusable. I haven't tested this but I think it should work.

https://phabricator.endlessm.com/T23364