### PR TITLE
deb: Install policy-rc.d to prevent services from starting

### DIFF
--- a/build-pkg-deb
+++ b/build-pkg-deb
@@ -48,6 +48,16 @@ deb_setup() {
     :>> $BUILD_ROOT/var/lib/dpkg/available
     :>> $BUILD_ROOT/var/log/dpkg.log
     :>> $BUILD_ROOT/etc/ld.so.conf
+
+    # Install a policy so that services are not started. See
+    # https://manpages.debian.org/unstable/init-system-helpers/invoke-rc.d.8.en.html
+    # for details.
+    mkdir -p $BUILD_ROOT/usr/sbin
+    cat > $BUILD_ROOT/usr/sbin/policy-rc.d <<EOF
+#!/bin/sh
+exit 101
+EOF
+    chmod 755 $BUILD_ROOT/usr/sbin/policy-rc.d
 }
 
 pkg_initdb_deb() {


### PR DESCRIPTION
Per invoke-rc.d(8), a local policy script can be created at
/usr/sbin/policy-rc.d to influence how services are started. When this
script exits with code 101, the requested service is not started. This
is independent of init system and is respected by all maintainer
scripts that comply with debian policy.

This is how debootstrap prevents services from running in the chroot. On
more recent debian and ubuntu releases where systemd is in use, it will
prevent services from starting by detecting that it's in a chroot, but
this method works independently of the init system. In our case this
fixes builds on Ubuntu Trusty where upstart is init. This change likely
makes the hack to replace /sbin/start with a symlink to /sbin/true
unnecessary. That hack is not comprehensive since it only handles the
start action and not stop, restart, reload, etc.

I tested this locally and it fixes trusty builds which have been broken since the obs-build upgrade. Soonish I hope to drop trusty as a target, but for now I'd just like to have builds working. I sent this upstream in openSUSE/obs-build#484.