### PR TITLE
build-recipe-dsc: pass the correct changes file to lintian

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -82,6 +82,7 @@ sed -i "s/\${PACKAGE} (\${VERSION})/\${PACKAGE} (\${VERSION}$OBS_DCH_RELEASE)/" 
 EOF
     elif test -z "$DEB_TRANSFORM"; then
 	# Use dch to apply new version in changelog
+	OBS_DCH_RELEASE="${RELEASE}"
 	DEBVERSION=$(egrep -m1 '^Version: ' $BUILD_ROOT/$DEB_SOURCEDIR/$DEB_DSCFILE  | sed 's/^Version:[ ]*//')
 	DEBREASON="${REASON:-Rebuild requested}"
 	rm -f $BUILD_ROOT/$TOPDIR/BUILD/debian/changelog.dch


### PR DESCRIPTION
In the lintian checks section, we are passing (e.g.)
gem2deb_0.40_amd64.changes for a package where the release version was
set via dch and the name is actually gem2deb_0.40bem1_amd64.changes.

This causes lintian to fail and the build aborts.

Set OBS_DCH_RELEASE in the dch codepath so that the changes filename
is correctly constructed for lintian checks.

https://phabricator.endlessm.com/T25137