### PR TITLE
control: Add dependency on python-lzma

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Package: obs-build
 Architecture: all
 Depends:
  ${misc:Depends}, ${perl:Depends}, rpm, debootstrap, sudo, libarchive-tools,
- python
+ python, python-lzma
 Recommends: rpm2cpio, osc, libcrypt-ssleay-perl, e2fsprogs, xzdec, xz-utils
 Suggests: xfsprogs, btrfs-tools
 Description: scripts for building RPM/debian packages for multiple distributions


### PR DESCRIPTION
When trying to use `osc build` I got the following error message:

    408/408 (eos:master:core) wget_1.20.1-1.1bem1_amd64.deb
    eos:master:core/wget: attempting download from api, since not found
    /tmp/osc_build_file2PVCKr: can't open control.tar.xz without python-lzma

Since many packages will be using control.tar.xz instead of
control.tar.gz I think it makes sense to add python-lzma as a
dependency.