### PR TITLE
Work around perl bug

### DIFF
--- a/Build/Deb.pm
+++ b/Build/Deb.pm
@@ -186,11 +186,12 @@ sub uncompress {
   local (*TMP, *TMP2);
   open(TMP, "+>", undef) or die("could not open tmpfile\n");
   syswrite TMP, $data;
-  sysseek(TMP, 0, 0);
   my $pid = open(TMP2, "-|");
   die("fork: $!\n") unless defined $pid;
   if (!$pid) {
     open(STDIN, "<&TMP");
+    seek(STDIN, 0, 0);
+    sysseek(STDIN, 0, 0);
     exec($tool);
     die("$tool: $!\n");
   }


### PR DESCRIPTION
Perl restores the postition in a file even after the file descriptor
has been replaced. So do a silly "seek(STDIN, 0, 0)".

(cherry picked from commit c1698c9af6fc501016347ed6332171c17d0bd39a)

This does seem to fix the issue. obs-build actually tries twice to run this code. First it feeds in a list of newline separated package file names on `stdin` and uses a script to loop through them. Presumably this is what causes the `stdin` position to shift around since it also uses `stdin` to feed `unxz`. If that process fails, then later it uses a different process to run this code one package at a time passing the package file name as an argument.

https://phabricator.endlessm.com/T26595