### PR TITLE
build-recipe-dsc: Set DEBEMAIL for dch

### DIFF
--- a/build-recipe-dsc
+++ b/build-recipe-dsc
@@ -86,7 +86,7 @@ EOF
 	DEBVERSION=$(egrep -m1 '^Version: ' $BUILD_ROOT/$DEB_SOURCEDIR/$DEB_DSCFILE  | sed 's/^Version:[ ]*//')
 	DEBREASON="${REASON:-Rebuild requested}"
 	rm -f $BUILD_ROOT/$TOPDIR/BUILD/debian/changelog.dch
-	chroot $BUILD_ROOT su -c "cd $TOPDIR/BUILD && dch  --preserve --force-distribution -D unstable -v ${DEBVERSION}${RELEASE} $DEBREASON" - $BUILD_USER
+	chroot $BUILD_ROOT su -c "cd $TOPDIR/BUILD && DEBEMAIL='Autobuild <autobuild@localhost>' dch  --preserve --force-distribution -D unstable -v ${DEBVERSION}${RELEASE} $DEBREASON" - $BUILD_USER
     fi
 
 }


### PR DESCRIPTION
Newer dch emits warnings if DEBEMAIL isn't set, which then blocks
waiting for acknowledgement of those warnings. This is equivalent to
what was previously being assembled from the passwd and hostname data.

https://phabricator.endlessm.com/T31537